### PR TITLE
Update Windows dll metadata to add UWP platform support

### DIFF
--- a/Plugins/lib/windows/arm64/gilzoide-sqlite-net.dll.meta
+++ b/Plugins/lib/windows/arm64/gilzoide-sqlite-net.dll.meta
@@ -21,8 +21,10 @@ PluginImporter:
         Exclude Linux64: 0
         Exclude OSXUniversal: 0
         Exclude WebGL: 1
-        Exclude Win: 1
+        Exclude Win: 0
         Exclude Win64: 0
+        Exclude WindowsStoreApps: 0
+        Exclude iOS: 1
   - first:
       Android: Android
     second:
@@ -48,25 +50,44 @@ PluginImporter:
     second:
       enabled: 1
       settings:
-        CPU: AnyCPU
+        CPU: None
   - first:
       Standalone: OSXUniversal
     second:
       enabled: 1
       settings:
-        CPU: AnyCPU
+        CPU: None
   - first:
       Standalone: Win
     second:
-      enabled: 0
+      enabled: 1
       settings:
-        CPU: AnyCPU
+        CPU: None
   - first:
       Standalone: Win64
     second:
       enabled: 1
       settings:
+        CPU: None
+  - first:
+      Windows Store Apps: WindowsStoreApps
+    second:
+      enabled: 1
+      settings:
         CPU: ARM64
+        DontProcess: false
+        PlaceholderPath: 
+        SDK: AnySDK
+        ScriptingBackend: AnyScriptingBackend
+  - first:
+      iPhone: iOS
+    second:
+      enabled: 0
+      settings:
+        AddToEmbeddedBinaries: false
+        CPU: AnyCPU
+        CompileFlags: 
+        FrameworkDependencies: 
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Plugins/lib/windows/arm64/gilzoide-sqlite-net.dll.meta
+++ b/Plugins/lib/windows/arm64/gilzoide-sqlite-net.dll.meta
@@ -21,10 +21,9 @@ PluginImporter:
         Exclude Linux64: 0
         Exclude OSXUniversal: 0
         Exclude WebGL: 1
-        Exclude Win: 0
+        Exclude Win: 1
         Exclude Win64: 0
         Exclude WindowsStoreApps: 0
-        Exclude iOS: 1
   - first:
       Android: Android
     second:
@@ -50,25 +49,25 @@ PluginImporter:
     second:
       enabled: 1
       settings:
-        CPU: None
+        CPU: AnyCPU
   - first:
       Standalone: OSXUniversal
     second:
       enabled: 1
       settings:
-        CPU: None
+        CPU: AnyCPU
   - first:
       Standalone: Win
     second:
-      enabled: 1
+      enabled: 0
       settings:
-        CPU: None
+        CPU: AnyCPU
   - first:
       Standalone: Win64
     second:
       enabled: 1
       settings:
-        CPU: None
+        CPU: ARM64
   - first:
       Windows Store Apps: WindowsStoreApps
     second:
@@ -79,15 +78,6 @@ PluginImporter:
         PlaceholderPath: 
         SDK: AnySDK
         ScriptingBackend: AnyScriptingBackend
-  - first:
-      iPhone: iOS
-    second:
-      enabled: 0
-      settings:
-        AddToEmbeddedBinaries: false
-        CPU: AnyCPU
-        CompileFlags: 
-        FrameworkDependencies: 
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Plugins/lib/windows/x86/gilzoide-sqlite-net.dll.meta
+++ b/Plugins/lib/windows/x86/gilzoide-sqlite-net.dll.meta
@@ -24,6 +24,7 @@ PluginImporter:
         Exclude WebGL: 1
         Exclude Win: 0
         Exclude Win64: 1
+        Exclude WindowsStoreApps: 0
         Exclude iOS: 1
         Exclude tvOS: 1
   - first:
@@ -79,6 +80,16 @@ PluginImporter:
         CPU: ARM64
         CompileFlags: 
         FrameworkDependencies: 
+  - first:
+      Windows Store Apps: WindowsStoreApps
+    second:
+      enabled: 1
+      settings:
+        CPU: X86
+        DontProcess: false
+        PlaceholderPath: 
+        SDK: AnySDK
+        ScriptingBackend: AnyScriptingBackend
   - first:
       iPhone: iOS
     second:

--- a/Plugins/lib/windows/x86_64/gilzoide-sqlite-net.dll.meta
+++ b/Plugins/lib/windows/x86_64/gilzoide-sqlite-net.dll.meta
@@ -24,6 +24,7 @@ PluginImporter:
         Exclude WebGL: 1
         Exclude Win: 1
         Exclude Win64: 0
+        Exclude WindowsStoreApps: 0
         Exclude iOS: 1
         Exclude tvOS: 1
   - first:
@@ -79,6 +80,16 @@ PluginImporter:
         CPU: ARM64
         CompileFlags: 
         FrameworkDependencies: 
+  - first:
+      Windows Store Apps: WindowsStoreApps
+    second:
+      enabled: 1
+      settings:
+        CPU: X64
+        DontProcess: false
+        PlaceholderPath: 
+        SDK: AnySDK
+        ScriptingBackend: AnyScriptingBackend
   - first:
       iPhone: iOS
     second:


### PR DESCRIPTION
WindowsStoreApps (UWP) platform support has been enabled on all of the Windows dll files. No editor or standalone support enabled on the ARM64 dll currently since this requires Unity 6, which is still in preview and not fully released.