### PR TITLE
Build WebGL bitcode using Emscripten version 1.40.1

### DIFF
--- a/Plugins/tools~/Dockerfile.build.webgl
+++ b/Plugins/tools~/Dockerfile.build.webgl
@@ -1,7 +1,3 @@
 # syntax=docker/dockerfile:1
-FROM debian:12-slim
-
-RUN apt-get -qq update \
-    && apt-get -qq install -y --no-install-recommends \
-        emscripten \
-        make
+# Using Emscripten 1.X for Unity <= 2021.2 support. It still works in 2021.3+.
+FROM emscripten/emsdk:1.40.1


### PR DESCRIPTION
This makes the file compatible with Unity versions 2021.2 and below.