### PR TITLE
Fix preserve ColumnInfo.Name property

### DIFF
--- a/Plugins/tools~/fix-library-path.sed
+++ b/Plugins/tools~/fix-library-path.sed
@@ -30,3 +30,7 @@ s/static string Quote/public static string Quote/
 
 # Make SQLite3 class partial, to extend in another file
 s/class SQLite3/partial class SQLite3/
+
+# Add [RequiredMember] attribute to ColumnInfo.Name property
+# This fixes managed code stripping removing its setter method
+s/Column ("name")/Column ("name"), UnityEngine.Scripting.RequiredMember/

--- a/README.md
+++ b/README.md
@@ -113,3 +113,4 @@ Third-party code:
 - `SQLiteConnection.Quote` is made public.
   This is be useful for libraries making raw queries.
 - `SQLite3.SetDirectory` is only defined in Windows platforms.
+- Adds a `[RequiredMember]` attribute to `ColumnInfo.Name` property, fixing errors on columns when managed code stripping is enabled.

--- a/Runtime/sqlite-net/SQLite.cs
+++ b/Runtime/sqlite-net/SQLite.cs
@@ -794,7 +794,7 @@ namespace SQLite
 		{
 			//			public int cid { get; set; }
 
-			[Column ("name")]
+			[Column ("name"), UnityEngine.Scripting.RequiredMember]
 			public string Name { get; set; }
 
 			//			[Column ("type")]


### PR DESCRIPTION
This fixes the "duplicate column name" error on builds with managed code stripping enabled (#30).