### PR TITLE
Make column attributes inherit Unity's PreserveAttribute

### DIFF
--- a/Plugins/Makefile
+++ b/Plugins/Makefile
@@ -92,7 +92,7 @@ lib/webgl/libgilzoide-sqlite-net.bc: $(SQLITE_SRC) | lib/webgl
 
 # Source
 $(SQLITE_NET_DEST)/%.cs: sqlite-net~/src/%.cs $(SQLITE_NET_SED_SCRIPT)
-	cat $< | sed -f $(SQLITE_NET_SED_SCRIPT) > $@
+	cat $< | sed -E -f $(SQLITE_NET_SED_SCRIPT) > $@
 
 $(SQLITE_NET_DEST)/License.txt: sqlite-net~/License.txt
 	cp $< $@

--- a/Plugins/tools~/fix-library-path.sed
+++ b/Plugins/tools~/fix-library-path.sed
@@ -30,9 +30,9 @@ s/static string Quote/public static string Quote/
 # Make SQLite3 class partial, to extend in another file
 s/class SQLite3/partial class SQLite3/
 
-# Add [RequiredMember] attribute to ColumnInfo.Name property
-# This fixes managed code stripping removing its setter method
-s/Column ("name")/Column ("name"), UnityEngine.Scripting.RequiredMember/
+# Make column attributes inherit Unity's RequiredMemberAttribute
+# This fixes managed code stripping removing getter/setter methods
+s/public class (PrimaryKey|AutoIncrement|Indexed|MaxLength|Collation|NotNull|StoreAsText)Attribute : Attribute/public class \1Attribute : UnityEngine.Scripting.RequiredMemberAttribute/
 
 # Use main thread TaskScheduler in WebGL
 s/TaskScheduler\.Default/SQLiteAsyncExtensions.TaskScheduler/

--- a/Plugins/tools~/fix-library-path.sed
+++ b/Plugins/tools~/fix-library-path.sed
@@ -30,9 +30,9 @@ s/static string Quote/public static string Quote/
 # Make SQLite3 class partial, to extend in another file
 s/class SQLite3/partial class SQLite3/
 
-# Make column attributes inherit Unity's RequiredMemberAttribute
+# Make column attributes inherit Unity's PreserveAttribute
 # This fixes managed code stripping removing getter/setter methods
-s/public class (PrimaryKey|AutoIncrement|Indexed|MaxLength|Collation|NotNull|StoreAsText)Attribute : Attribute/public class \1Attribute : UnityEngine.Scripting.RequiredMemberAttribute/
+s/public class (Column|PrimaryKey|AutoIncrement|Indexed|MaxLength|Collation|NotNull|StoreAsText)Attribute : Attribute/public class \1Attribute : UnityEngine.Scripting.PreserveAttribute/
 
 # Use main thread TaskScheduler in WebGL
 s/TaskScheduler\.Default/SQLiteAsyncExtensions.TaskScheduler/

--- a/README.md
+++ b/README.md
@@ -113,6 +113,6 @@ Third-party code:
 - `SQLiteConnection.Quote` is made public.
   This is useful for libraries making raw queries.
 - `SQLite3.SetDirectory` is only defined in Windows platforms.
-- Makes all column related attributes inherit `RequiredMemberAttribute`, fixing errors on columns when managed code stripping is enabled.
+- Makes all column related attributes inherit `PreserveAttribute`, fixing errors on columns when managed code stripping is enabled.
 - Changes the `TaskScheduler` used by the async API on WebGL to one that executes tasks on Unity's main thread.
 - Fix support for struct return types in queries

--- a/README.md
+++ b/README.md
@@ -113,6 +113,6 @@ Third-party code:
 - `SQLiteConnection.Quote` is made public.
   This is useful for libraries making raw queries.
 - `SQLite3.SetDirectory` is only defined in Windows platforms.
-- Adds a `[RequiredMember]` attribute to `ColumnInfo.Name` property, fixing errors on columns when managed code stripping is enabled.
+- Makes all column related attributes inherit `RequiredMemberAttribute`, fixing errors on columns when managed code stripping is enabled.
 - Changes the `TaskScheduler` used by the async API on WebGL to one that executes tasks on Unity's main thread.
 - Fix support for struct return types in queries

--- a/Runtime/sqlite-net/SQLite.cs
+++ b/Runtime/sqlite-net/SQLite.cs
@@ -2454,7 +2454,7 @@ namespace SQLite
 	}
 
 	[AttributeUsage (AttributeTargets.Property)]
-	public class ColumnAttribute : Attribute
+	public class ColumnAttribute : UnityEngine.Scripting.PreserveAttribute
 	{
 		public string Name { get; set; }
 
@@ -2465,17 +2465,17 @@ namespace SQLite
 	}
 
 	[AttributeUsage (AttributeTargets.Property)]
-	public class PrimaryKeyAttribute : UnityEngine.Scripting.RequiredMemberAttribute
+	public class PrimaryKeyAttribute : UnityEngine.Scripting.PreserveAttribute
 	{
 	}
 
 	[AttributeUsage (AttributeTargets.Property)]
-	public class AutoIncrementAttribute : UnityEngine.Scripting.RequiredMemberAttribute
+	public class AutoIncrementAttribute : UnityEngine.Scripting.PreserveAttribute
 	{
 	}
 
 	[AttributeUsage (AttributeTargets.Property, AllowMultiple = true)]
-	public class IndexedAttribute : UnityEngine.Scripting.RequiredMemberAttribute
+	public class IndexedAttribute : UnityEngine.Scripting.PreserveAttribute
 	{
 		public string Name { get; set; }
 		public int Order { get; set; }
@@ -2507,7 +2507,7 @@ namespace SQLite
 	}
 
 	[AttributeUsage (AttributeTargets.Property)]
-	public class MaxLengthAttribute : UnityEngine.Scripting.RequiredMemberAttribute
+	public class MaxLengthAttribute : UnityEngine.Scripting.PreserveAttribute
 	{
 		public int Value { get; private set; }
 
@@ -2529,7 +2529,7 @@ namespace SQLite
 	/// "BINARY" is the default.
 	/// </summary>
 	[AttributeUsage (AttributeTargets.Property)]
-	public class CollationAttribute : UnityEngine.Scripting.RequiredMemberAttribute
+	public class CollationAttribute : UnityEngine.Scripting.PreserveAttribute
 	{
 		public string Value { get; private set; }
 
@@ -2540,12 +2540,12 @@ namespace SQLite
 	}
 
 	[AttributeUsage (AttributeTargets.Property)]
-	public class NotNullAttribute : UnityEngine.Scripting.RequiredMemberAttribute
+	public class NotNullAttribute : UnityEngine.Scripting.PreserveAttribute
 	{
 	}
 
 	[AttributeUsage (AttributeTargets.Enum)]
-	public class StoreAsTextAttribute : UnityEngine.Scripting.RequiredMemberAttribute
+	public class StoreAsTextAttribute : UnityEngine.Scripting.PreserveAttribute
 	{
 	}
 

--- a/Runtime/sqlite-net/SQLite.cs
+++ b/Runtime/sqlite-net/SQLite.cs
@@ -919,7 +919,7 @@ namespace SQLite
 		{
 			//			public int cid { get; set; }
 
-			[Column ("name"), UnityEngine.Scripting.RequiredMember]
+			[Column ("name")]
 			public string Name { get; set; }
 
 			//			[Column ("type")]
@@ -2465,17 +2465,17 @@ namespace SQLite
 	}
 
 	[AttributeUsage (AttributeTargets.Property)]
-	public class PrimaryKeyAttribute : Attribute
+	public class PrimaryKeyAttribute : UnityEngine.Scripting.RequiredMemberAttribute
 	{
 	}
 
 	[AttributeUsage (AttributeTargets.Property)]
-	public class AutoIncrementAttribute : Attribute
+	public class AutoIncrementAttribute : UnityEngine.Scripting.RequiredMemberAttribute
 	{
 	}
 
 	[AttributeUsage (AttributeTargets.Property, AllowMultiple = true)]
-	public class IndexedAttribute : Attribute
+	public class IndexedAttribute : UnityEngine.Scripting.RequiredMemberAttribute
 	{
 		public string Name { get; set; }
 		public int Order { get; set; }
@@ -2507,7 +2507,7 @@ namespace SQLite
 	}
 
 	[AttributeUsage (AttributeTargets.Property)]
-	public class MaxLengthAttribute : Attribute
+	public class MaxLengthAttribute : UnityEngine.Scripting.RequiredMemberAttribute
 	{
 		public int Value { get; private set; }
 
@@ -2529,7 +2529,7 @@ namespace SQLite
 	/// "BINARY" is the default.
 	/// </summary>
 	[AttributeUsage (AttributeTargets.Property)]
-	public class CollationAttribute : Attribute
+	public class CollationAttribute : UnityEngine.Scripting.RequiredMemberAttribute
 	{
 		public string Value { get; private set; }
 
@@ -2540,12 +2540,12 @@ namespace SQLite
 	}
 
 	[AttributeUsage (AttributeTargets.Property)]
-	public class NotNullAttribute : Attribute
+	public class NotNullAttribute : UnityEngine.Scripting.RequiredMemberAttribute
 	{
 	}
 
 	[AttributeUsage (AttributeTargets.Enum)]
-	public class StoreAsTextAttribute : Attribute
+	public class StoreAsTextAttribute : UnityEngine.Scripting.RequiredMemberAttribute
 	{
 	}
 


### PR DESCRIPTION
This fixes managed code stripping removing getter/setter methods. Fixes #52.